### PR TITLE
Slacksoc v1.1.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM golang:alpine
 
-RUN apk add --update git && rm -rf /var/cache/apk/*
+RUN apk add --update git tzdata && rm -rf /var/cache/apk/*
+RUN ln -sf /usr/share/zoneinfo/America/New_York /etc/localtime
 
 COPY . $GOPATH/src/github.com/hacsoc/slacksoc
 


### PR DESCRIPTION
https://github.com/brenns10/slacksoc/blob/master/CHANGELOG.md

Fixes the second/minute mixup as well as the hotpotato help formatting. Dockerfile is updated here so that we set the local time to be America/New_York